### PR TITLE
Improve performance of extended cells and avoid to display old entry after sorting/filtering

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/Cell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/Cell.java
@@ -24,7 +24,6 @@
 package com.ponysdk.core.ui.datagrid2.cell;
 
 import com.ponysdk.core.ui.basic.IsPWidget;
-import com.ponysdk.core.ui.basic.PWidget;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 
 /**
@@ -35,25 +34,7 @@ import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
  *
  * @author mbagdouri
  */
-public interface Cell<V> extends IsPWidget {
-
-    /**
-     * Must always return the same instance and cannot be {@code null} or the
-     * same as the main widget.
-     *
-     * @return a widget that will replace the main widget when the value for
-     *         this cell is not available
-     */
-    PWidget asPendingWidget();
-
-    /**
-     * Renders the value in the main widget.
-     *
-     * @param data the value to be rendered
-     * @param renderingHelper the intermediate object supplied in
-     *            {@link ColumnDefinition#getRenderingHelper(Object)}
-     */
-    void render(V data, Object renderingHelper);
+public interface Cell<V, C extends CellController<V>> extends IsPWidget {
 
     /**
      * Sets a {@link CellController} that can be used to make cell/row related
@@ -62,7 +43,18 @@ public interface Cell<V> extends IsPWidget {
      *
      * @param cellController
      */
-    void setController(CellController<V> cellController);
+    void setController(C cellController);
+
+    /**
+     * Renders the value in the main widget.
+     *
+     * @param data
+     *            the value to be rendered
+     * @param renderingHelper
+     *            the intermediate object supplied in
+     *            {@link ColumnDefinition#getRenderingHelper(Object)}
+     */
+    void render(V data, Object renderingHelper);
 
     /**
      * Called when the row that this cell belongs to is selected

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/CellController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/CellController.java
@@ -29,16 +29,6 @@ package com.ponysdk.core.ui.datagrid2.cell;
 public interface CellController<V> {
 
     /**
-     * Switches to an extended mode that can be used to have a richer cell not
-     * constrained by the dimensions of the original cell. The
-     * {@link ExtendedCell} can be used, for example, for the edit mode or for
-     * having a more detailed view.
-     *
-     * @see ExtendedCellController#cancelExtendedMode()
-     */
-    void extendedMode(ExtendedCell<V> extendedCell);
-
-    /**
      * Selects the row that this cell belongs to
      */
     void selectRow();

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/DecoratorCell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/DecoratorCell.java
@@ -23,17 +23,18 @@
 
 package com.ponysdk.core.ui.datagrid2.cell;
 
+import java.util.Optional;
+
 import com.ponysdk.core.ui.basic.PWidget;
 
 /**
  * @author mbagdouri
  */
-public class DecoratorCell<V> implements Cell<V> {
+public class DecoratorCell<V, DELEGATE extends PrimaryCell<V>> implements PrimaryCell<V> {
 
-    private final Cell<V> cell;
+    private final DELEGATE cell;
 
-    public DecoratorCell(final Cell<V> cell) {
-        super();
+    public DecoratorCell(final DELEGATE cell) {
         this.cell = cell;
     }
 
@@ -48,12 +49,17 @@ public class DecoratorCell<V> implements Cell<V> {
     }
 
     @Override
+    public Optional<ExtendedCell<V>> genExtended() {
+        return cell.genExtended();
+    }
+
+    @Override
     public void render(final V data, final Object renderingHelper) {
         cell.render(data, renderingHelper);
     }
 
     @Override
-    public void setController(final CellController<V> cellController) {
+    public void setController(final PrimaryCellController<V> cellController) {
         cell.setController(cellController);
     }
 
@@ -67,7 +73,7 @@ public class DecoratorCell<V> implements Cell<V> {
         cell.unselect();
     }
 
-    protected Cell<V> getCell() {
+    public DELEGATE getDelegate() {
         return cell;
     }
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/ExtendedCell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/ExtendedCell.java
@@ -23,54 +23,13 @@
 
 package com.ponysdk.core.ui.datagrid2.cell;
 
-import com.ponysdk.core.ui.basic.IsPWidget;
-import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
-
 /**
- * {@code ExtendedCell} is created when a {@link Cell} is switched to mode
- * extended. {@code ExtendedCell} will be always bound to the same key, but its
- * data might change in case the model is updated.
- * The {@link IsPWidget#asWidget()} method must always return the same instance
- * of the main widget that will be used for the rendering of the value.
- *
+ * {@link Cell} made visible when {@link PrimaryCellController#setExtendedMode()} is called.<br><br>
+ * {@link ExtendedCell}'s height is not constrained as it is the case for a {@link PrimaryCell}.
+ * 
  * @author mbagdouri
- * @see CellController#extendedMode(ExtendedCell)
+ * @see Cell
+ * @see PrimaryCellController#setExtendedMode()
  */
-public interface ExtendedCell<V> extends IsPWidget {
-
-    /**
-     * Sets the most recent value on this cell. This value can be the same as
-     * the value previously set (i.e. when this method is called, it is not
-     * guaranteed that the value has changed)
-     */
-    void setValue(V v);
-
-    /**
-     * Sets a {@link ExtendedCellController} that can be used to make cell/row
-     * related actions. It will be set as soon as the
-     * {@link ColumnDefinition#createCell()} is called.
-     *
-     * @param extendedCellController
-     */
-    void setController(ExtendedCellController<V> extendedCellController);
-
-    /**
-     * Called when the row that this cell belongs to is selected
-     */
-    void select();
-
-    /**
-     * Called when the row that this cell belongs to is unselected
-     */
-    void unselect();
-
-    /**
-     * Called before each time this cell is removed from its parent
-     */
-    void beforeRemove();
-
-    /**
-     * Called after each time this cell is added to a parent widget
-     */
-    void afterAdd();
+public interface ExtendedCell<V> extends Cell<V, ExtendedCellController<V>> {
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/ExtendedCellController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/ExtendedCellController.java
@@ -28,25 +28,14 @@ import java.util.function.Consumer;
 /**
  * @author mbagdouri
  */
-public interface ExtendedCellController<V> {
+public interface ExtendedCellController<V> extends CellController<V> {
 
     /**
-     * Switched back from extended mode to normal mode and removes the
-     * {@link ExtendedCell} from the view
+     * Switches back from extended mode to primary mode ({@link ExtendedCell} become invisible in the view).
      *
-     * @see CellController#extendedMode(ExtendedCell)
+     * @see PrimaryCellController#setExtendedMode()
      */
-    void cancelExtendedMode();
-
-    /**
-     * Selects the row that this cell belongs to
-     */
-    void selectRow();
-
-    /**
-     * Selects the row that this cell belongs to
-     */
-    void unselectRow();
+    void setPrimaryMode();
 
     /**
      * Replaces the value in the model, corresponding to this cell's key, with

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/LabelCell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/LabelCell.java
@@ -23,7 +23,9 @@
 
 package com.ponysdk.core.ui.datagrid2.cell;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import com.ponysdk.core.ui.basic.Element;
 import com.ponysdk.core.ui.basic.PLabel;
@@ -32,16 +34,23 @@ import com.ponysdk.core.ui.basic.PWidget;
 /**
  * @author mbagdouri
  */
-public class LabelCell<V> implements Cell<V> {
+public class LabelCell<V> implements PrimaryCell<V> {
 
     private final PLabel label = Element.newPLabel();
     private final PLabel pendingLabel = Element.newPLabel("...");
-    private CellController<V> cellController;
+    private PrimaryCellController<V> cellController;
+    private Supplier<ExtendedCell<V>> instantiator;
 
     public LabelCell(final BiConsumer<V, String> columnEditFn, final int width) {
+    	instantiator = () -> new TextBoxExtendedCell<>(label.getText(), columnEditFn, width);
         label.addDoubleClickHandler(e -> {
-            if (cellController != null) cellController.extendedMode(new TextBoxExtendedCell<>(label.getText(), columnEditFn, width));
+            if (cellController != null) cellController.setExtendedMode();
         });
+    }
+    
+    @Override
+    public Optional<ExtendedCell<V>> genExtended() {
+    	return Optional.of(instantiator.get());
     }
 
     @Override
@@ -60,7 +69,7 @@ public class LabelCell<V> implements Cell<V> {
     }
 
     @Override
-    public void setController(final CellController<V> cellController) {
+    public void setController(final PrimaryCellController<V> cellController) {
         this.cellController = cellController;
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/PrimaryCell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/PrimaryCell.java
@@ -1,0 +1,30 @@
+package com.ponysdk.core.ui.datagrid2.cell;
+
+import java.util.Optional;
+
+import com.ponysdk.core.ui.basic.PWidget;
+
+/**
+ * {@link Cell} made visible by default and when {@link ExtendedCellController#setPrimaryMode()} is called.<br><br>
+ * All {@link PrimaryCell} are expected to have the same immutable height for a given {@code DataGridView}.
+ * 
+ * @author pvbossche
+ */
+public interface PrimaryCell<V> extends Cell<V, PrimaryCellController<V>> {
+	/**
+     * Must always return the same instance and cannot be {@code null} or the
+     * same as the main widget.
+     *
+     * @return a widget that will replace the main widget when the value for
+     *         this cell is not available
+     */
+    PWidget asPendingWidget();
+    
+    /**
+     * @return a fresh new instance of an {@link ExtendedCell} corresponding to this cell
+     *  (or none if not possible; in that case, no {@link ExtendedCell} will be added to {@code DataGridView}).
+     */
+    default Optional<ExtendedCell<V>> genExtended() {
+        return Optional.empty();
+    }
+}

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/PrimaryCellController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/PrimaryCellController.java
@@ -1,0 +1,23 @@
+/*============================================================================
+ *
+ * Copyright (c) 2000-2022 Smart Trade Technologies. All Rights Reserved.
+ *
+ * This software is the proprietary information of Smart Trade Technologies
+ * Use is subject to license terms. Duplication or distribution prohibited.
+ *
+ *============================================================================*/
+
+package com.ponysdk.core.ui.datagrid2.cell;
+
+public interface PrimaryCellController<V> extends CellController<V> {
+
+    /**
+     * Switches to an extended mode that can be used to have a richer cell not
+     * constrained by the dimensions of the original cell. The
+     * {@link ExtendedCell} can be used, for example, for the edit mode or for
+     * having a more detailed view.
+     *
+     * @see ExtendedCellController#setPrimaryMode()
+     */
+    void setExtendedMode();
+}

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/TextBoxExtendedCell.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/cell/TextBoxExtendedCell.java
@@ -28,25 +28,22 @@ import java.util.function.BiConsumer;
 import com.ponysdk.core.ui.basic.Element;
 import com.ponysdk.core.ui.basic.PTextBox;
 import com.ponysdk.core.ui.basic.PWidget;
-import com.ponysdk.core.ui.basic.event.PBlurEvent;
-import com.ponysdk.core.ui.basic.event.PBlurHandler;
 import com.ponysdk.core.ui.model.PEventType;
 import com.ponysdk.core.ui.model.PKeyCodes;
 
 /**
  * @author mbagdouri
  */
-public class TextBoxExtendedCell<V> implements ExtendedCell<V>, PBlurHandler {
+public class TextBoxExtendedCell<V> implements ExtendedCell<V> {
 
     private final PTextBox textBox = Element.newPTextBox();
     private ExtendedCellController<V> extendedCellController;
-    private boolean focused = false;
 
     public TextBoxExtendedCell(final String text, final BiConsumer<V, String> columnEditFn, final int width) {
         textBox.setText(text);
         textBox.addBlurHandler(e -> {
             if (extendedCellController == null) return;
-            extendedCellController.cancelExtendedMode();
+            extendedCellController.setPrimaryMode();
         });
         textBox.addClickHandler(e -> {
 
@@ -56,14 +53,11 @@ public class TextBoxExtendedCell<V> implements ExtendedCell<V>, PBlurHandler {
         textBox.addKeyUpHandler(e -> {
             if (extendedCellController == null) return;
             if (e.getKeyCode() == PKeyCodes.ENTER.getCode()) {
-                extendedCellController.cancelExtendedMode();
+                extendedCellController.setPrimaryMode();
                 extendedCellController.updateValue((v) -> columnEditFn.accept(v, textBox.getText()));
             } else if (e.getKeyCode() == PKeyCodes.ESCAPE.getCode()) {
-                extendedCellController.cancelExtendedMode();
+                extendedCellController.setPrimaryMode();
             }
-        });
-        textBox.addFocusHandler(e -> {
-            focused = true;
         });
         textBox.setWidth(width + "px");
     }
@@ -86,24 +80,7 @@ public class TextBoxExtendedCell<V> implements ExtendedCell<V>, PBlurHandler {
     public void unselect() {
     }
 
-    @Override
-    public void setValue(final V v) {
-    }
-
-    @Override
-    public void beforeRemove() {
-        textBox.removeDomHandler(this, PBlurEvent.TYPE);
-    }
-
-    @Override
-    public void afterAdd() {
-        if (focused) textBox.focusPreventScroll();
-        textBox.addBlurHandler(this);
-    }
-
-    @Override
-    public void onBlur(final PBlurEvent event) {
-        focused = false;
-    }
-
+	@Override
+	public void render(V data, Object renderingHelper) {
+	}
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/ColumnDefinition.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/ColumnDefinition.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import com.ponysdk.core.ui.basic.IsPWidget;
 import com.ponysdk.core.ui.datagrid2.adapter.DataGridAdapter;
 import com.ponysdk.core.ui.datagrid2.cell.Cell;
+import com.ponysdk.core.ui.datagrid2.cell.PrimaryCell;
 import com.ponysdk.core.ui.datagrid2.view.DataGridView;
 
 /**
@@ -75,7 +76,7 @@ public interface ColumnDefinition<V> extends ColumnActionListener<V> {
      * @return a new widget that will be used as a cell in the body of the
      *         {@link DataGridView} for this column.
      */
-    Cell<V> createCell();
+    PrimaryCell<V> createCell();
 
     /**
      * Returns an intermediate object that will be cached in order to be used

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/DecoratorColumnDefinition.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/DecoratorColumnDefinition.java
@@ -27,7 +27,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
 import com.ponysdk.core.ui.basic.IsPWidget;
-import com.ponysdk.core.ui.datagrid2.cell.Cell;
+import com.ponysdk.core.ui.datagrid2.cell.PrimaryCell;
 
 /**
  * @author mbagdouri
@@ -91,7 +91,7 @@ public class DecoratorColumnDefinition<V> implements ColumnDefinition<V> {
     }
 
     @Override
-    public Cell<V> createCell() {
+    public PrimaryCell<V> createCell() {
         return column.createCell();
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/DefaultColumnDefinition.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/column/DefaultColumnDefinition.java
@@ -32,8 +32,8 @@ import com.ponysdk.core.ui.basic.Element;
 import com.ponysdk.core.ui.basic.IsPWidget;
 import com.ponysdk.core.ui.basic.PComplexPanel;
 import com.ponysdk.core.ui.basic.PLabel;
-import com.ponysdk.core.ui.datagrid2.cell.Cell;
 import com.ponysdk.core.ui.datagrid2.cell.LabelCell;
+import com.ponysdk.core.ui.datagrid2.cell.PrimaryCell;
 
 /**
  * @author mbagdouri
@@ -93,7 +93,7 @@ public class DefaultColumnDefinition<V> implements ColumnDefinition<V> {
     }
 
     @Override
-    public Cell<V> createCell() {
+    public PrimaryCell<V> createCell() {
         return new LabelCell<>(columnEditFn, (int) (getDefaultWidth() * 0.8));
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
@@ -37,6 +37,7 @@ import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
 import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
+import com.ponysdk.core.ui.datagrid2.view.DataGridView;
 
 /**
  * @author mbagdouri
@@ -103,7 +104,20 @@ public interface DataGridController<K, V> {
 
     void enrichConfigBuilder(DataGridConfigBuilder<V> builder);
 
+    /** 
+     * Performs a full refresh; i.e. same as {@link #refreshOnNextDraw()} but with a forced redraw on {@link DataGridView} afterwards.
+     */
     void refresh();
+    
+    /**
+     * Ensures that all data will be refreshed during the next draw performed on {@link DataGridView} but without performing it immediately.<br><br>
+     * Indeed, a performance mechanism limits the rows which gets refreshed during a draw and this refresh ensures the whole dataset will be refreshed.<br><br>
+     * 
+     *  splits the data in 2 zones: a constant one and a variable one. 
+     * The variable zone is the only one that gets updated during a draw and it is constantly narrowed down for better performance.<br><br>
+     * This refresh will grow the variable zone on the whole dataset so that it gets updated next time but it will not force any redraw.
+     */
+    void refreshOnNextDraw();
 
     /**
      * Send a partially filled object to the dataSource. The object will return

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
@@ -33,7 +33,6 @@ import java.util.function.Supplier;
 
 import com.ponysdk.core.ui.datagrid2.adapter.DataGridAdapter;
 import com.ponysdk.core.ui.datagrid2.cell.Cell;
-import com.ponysdk.core.ui.datagrid2.cell.ExtendedCell;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
@@ -45,9 +44,7 @@ import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
 
 public interface DataGridController<K, V> {
 
-    void renderCell(ColumnDefinition<V> column, Cell<V> widget, V data);
-
-    void setValueOnExtendedCell(ExtendedCell<V> widget, V data);
+    void renderCell(ColumnDefinition<V> column, Cell<V, ?> widget, V data);
 
     boolean isSelected(K k);
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
@@ -37,7 +37,6 @@ import com.ponysdk.core.ui.datagrid2.cell.ExtendedCell;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
-import com.ponysdk.core.ui.datagrid2.data.LiveDataView;
 import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
 
 /**
@@ -46,9 +45,9 @@ import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
 
 public interface DataGridController<K, V> {
 
-    void renderCell(ColumnDefinition<V> column, int row, Cell<V> widget, LiveDataView<V> result);
+    void renderCell(ColumnDefinition<V> column, Cell<V> widget, V data);
 
-    void setValueOnExtendedCell(int row, ExtendedCell<V> widget, LiveDataView<V> result);
+    void setValueOnExtendedCell(ExtendedCell<V> widget, V data);
 
     boolean isSelected(K k);
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridControllerListener.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridControllerListener.java
@@ -26,4 +26,6 @@ package com.ponysdk.core.ui.datagrid2.controller;
 public interface DataGridControllerListener<V> {
 
     void onUpdateRows(int from, int to);
+    
+    void refresh();
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
@@ -134,11 +134,11 @@ public class DefaultDataGridController<K, V> implements DataGridController<K, V>
     }
 
     private void clearRenderingHelpers(final DefaultRow<V> row) {
-        renderingHelpersCache.remove(row);
+        renderingHelpersCache.remove(row.getData());
     }
 
     private void clearRenderingHelper(final DefaultRow<V> row, final Column<V> column) {
-        final Object[] renderingHelpers = renderingHelpersCache.get(row);
+        final Object[] renderingHelpers = renderingHelpersCache.get(row.getData());
         if (renderingHelpers == null) return;
         renderingHelpers[column.getID()] = null;
     }
@@ -242,7 +242,7 @@ public class DefaultDataGridController<K, V> implements DataGridController<K, V>
     public final V removeData(final K k) {
         final DefaultRow<V> row = dataSource.getRow(k);
         if (row == null) return null;
-        renderingHelpersCache.remove(row);
+        renderingHelpersCache.remove(row.getData());
         final V v = dataSource.removeData(k);
         refreshOnNextDraw();
         return v;

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import com.ponysdk.core.ui.datagrid2.adapter.DataGridAdapter;
 import com.ponysdk.core.ui.datagrid2.cell.Cell;
-import com.ponysdk.core.ui.datagrid2.cell.ExtendedCell;
 import com.ponysdk.core.ui.datagrid2.column.Column;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
@@ -243,16 +242,10 @@ public class DefaultDataGridController<K, V> implements DataGridController<K, V>
     }
 
     @Override
-    public void renderCell(final ColumnDefinition<V> colDef, final Cell<V> cell, final V data) {
+    public void renderCell(final ColumnDefinition<V> colDef, final Cell<V, ?> cell, final V data) {
         checkAdapter();
         final Column<V> column = getColumn(colDef);
         cell.render(data, getRenderingHelper(data, column));
-    }
-
-    @Override
-    public void setValueOnExtendedCell(final ExtendedCell<V> extendedCell, final V data) {
-        checkAdapter();
-        extendedCell.setValue(data);
     }
 
     @Override

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
@@ -255,7 +255,12 @@ public abstract class SpyDataGridController<K, V> implements DataGridController<
     }
 
     @Override
+    public void refreshOnNextDraw() {
+        controller.refreshOnNextDraw();
+    }
+    
+    @Override
     public void refresh() {
-        controller.refresh();
+    	controller.refresh();
     }
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
@@ -37,7 +37,6 @@ import com.ponysdk.core.ui.datagrid2.cell.ExtendedCell;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
-import com.ponysdk.core.ui.datagrid2.data.LiveDataView;
 import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
 
 /**
@@ -105,13 +104,13 @@ public abstract class SpyDataGridController<K, V> implements DataGridController<
     protected abstract void onDataUpdate();
 
     @Override
-    public void renderCell(final ColumnDefinition<V> column, final int row, final Cell<V> widget, final LiveDataView<V> result) {
-        controller.renderCell(column, row, widget, result);
+    public void renderCell(final ColumnDefinition<V> column, final Cell<V> widget, final V data) {
+        controller.renderCell(column, widget, data);
     }
 
     @Override
-    public void setValueOnExtendedCell(final int row, final ExtendedCell<V> widget, final LiveDataView<V> result) {
-        setValueOnExtendedCell(row, widget, result);
+    public void setValueOnExtendedCell(final ExtendedCell<V> widget, final V data) {
+        setValueOnExtendedCell(widget, data);
     }
 
     @Override
@@ -120,7 +119,7 @@ public abstract class SpyDataGridController<K, V> implements DataGridController<
     }
 
     @Override
-    public boolean isSelectable(K k) {
+    public boolean isSelectable(final K k) {
         return controller.isSelectable(k);
     }
     

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
@@ -33,7 +33,6 @@ import java.util.function.Supplier;
 
 import com.ponysdk.core.ui.datagrid2.adapter.DataGridAdapter;
 import com.ponysdk.core.ui.datagrid2.cell.Cell;
-import com.ponysdk.core.ui.datagrid2.cell.ExtendedCell;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
@@ -104,13 +103,8 @@ public abstract class SpyDataGridController<K, V> implements DataGridController<
     protected abstract void onDataUpdate();
 
     @Override
-    public void renderCell(final ColumnDefinition<V> column, final Cell<V> widget, final V data) {
+    public void renderCell(final ColumnDefinition<V> column, final Cell<V, ?> widget, final V data) {
         controller.renderCell(column, widget, data);
-    }
-
-    @Override
-    public void setValueOnExtendedCell(final ExtendedCell<V> widget, final V data) {
-        setValueOnExtendedCell(widget, data);
     }
 
     @Override

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/AbstractDataSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/AbstractDataSource.java
@@ -44,6 +44,7 @@ import com.ponysdk.core.ui.datagrid2.controller.DefaultDataGridController;
 import com.ponysdk.core.ui.datagrid2.controller.DefaultDataGridController.RenderingHelpersCache;
 import com.ponysdk.core.ui.datagrid2.data.AbstractFilter;
 import com.ponysdk.core.ui.datagrid2.data.DefaultRow;
+import com.ponysdk.core.util.MappedList;
 
 /**
  * @author mabbas
@@ -60,8 +61,8 @@ public abstract class AbstractDataSource<K, V> implements DataGridSource<K, V> {
     protected int rowCounter = 0;
 
     @Override
-    public List<DefaultRow<V>> getLiveSelectedData() {
-        return liveSelectedData;
+    public List<V> getLiveSelectedData() {
+        return new MappedList<>(liveSelectedData, DefaultRow::getData);
     }
 
     @Override
@@ -161,13 +162,13 @@ public abstract class AbstractDataSource<K, V> implements DataGridSource<K, V> {
     }
 
     @Override
-    public Comparator<DefaultRow<V>> clearSort(final Column<V> column) {
-        return sorts.remove(column);
+    public boolean clearSort(final Column<V> column) {
+        return sorts.remove(column) != null;
     }
 
     @Override
-    public Comparator<DefaultRow<V>> clearSort(final Object key) {
-        return sorts.remove(key);
+    public boolean clearSort(final Object key) {
+        return sorts.remove(key) != null;
     }
 
     @Override
@@ -187,8 +188,8 @@ public abstract class AbstractDataSource<K, V> implements DataGridSource<K, V> {
     }
 
     @Override
-    public AbstractFilter<V> clearFilter(final Object key) {
-        return filters.remove(key);
+    public boolean clearFilter(final Object key) {
+        return filters.remove(key) != null;
     }
 
     @Override

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DataGridSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DataGridSource.java
@@ -86,7 +86,7 @@ public interface DataGridSource<K, V> {
     /**
      * @return the list that contains selected data
      */
-    List<DefaultRow<V>> getLiveSelectedData();
+    List<V> getLiveSelectedData();
 
     /**
      * Adapter setter
@@ -107,12 +107,11 @@ public interface DataGridSource<K, V> {
 
     void addPrimarySort(Object key, Comparator<DefaultRow<V>> comparator);
 
-    /**
-     * Remove a sort
-     */
-    Comparator<DefaultRow<V>> clearSort(Column<V> column);
+    /** @return true iff a sort has been removed */
+    boolean clearSort(Column<V> column);
 
-    Comparator<DefaultRow<V>> clearSort(Object key);
+    /** @return true iff a sort has been removed */
+    boolean clearSort(Object key);
 
     /**
      * Clear all sorting
@@ -134,10 +133,8 @@ public interface DataGridSource<K, V> {
      */
     void setFilter(final Object key, String id, final boolean reinforcing, final AbstractFilter<V> filter);
 
-    /**
-     * Clear a filter
-     */
-    AbstractFilter<V> clearFilter(Object key);
+    /** @return true iff a filter has been removed */
+    boolean clearFilter(Object key);
 
     void clearFilters(ColumnDefinition<V> column);
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DefaultCacheDataSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DefaultCacheDataSource.java
@@ -164,8 +164,8 @@ public class DefaultCacheDataSource<K, V> extends AbstractDataSource<K, V> {
     }
 
     private void clearRenderingHelpers(final DefaultRow<V> row) {
-        if (renderingHelpersCache.get(row) != null) {
-            renderingHelpersCache.remove(row);
+        if (renderingHelpersCache.get(row.getData()) != null) {
+            renderingHelpersCache.remove(row.getData());
         }
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/RowSelectorColumnDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/RowSelectorColumnDataGridView.java
@@ -38,8 +38,8 @@ import com.ponysdk.core.ui.basic.PWidget;
 import com.ponysdk.core.ui.basic.event.PValueChangeEvent;
 import com.ponysdk.core.ui.datagrid2.adapter.DataGridAdapter;
 import com.ponysdk.core.ui.datagrid2.adapter.DecoratorDataGridAdapter;
-import com.ponysdk.core.ui.datagrid2.cell.Cell;
-import com.ponysdk.core.ui.datagrid2.cell.CellController;
+import com.ponysdk.core.ui.datagrid2.cell.PrimaryCell;
+import com.ponysdk.core.ui.datagrid2.cell.PrimaryCellController;
 import com.ponysdk.core.ui.datagrid2.column.ColumnController;
 import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
@@ -187,7 +187,7 @@ public class RowSelectorColumnDataGridView<K, V> extends DecoratorDataGridView<K
         }
 
         @Override
-        public Cell<V> createCell() {
+        public PrimaryCell<V> createCell() {
             return new RowSelectorColumnCell();
         }
 
@@ -278,7 +278,7 @@ public class RowSelectorColumnDataGridView<K, V> extends DecoratorDataGridView<K
             refreshHeader();
         }
 
-        private class RowSelectorColumnCell implements Cell<V> {
+        private class RowSelectorColumnCell implements PrimaryCell<V> {
 
             private final PCheckBox checkBox = Element.newPCheckBox();
             private final PWidget pending = Element.newSpan();
@@ -293,7 +293,7 @@ public class RowSelectorColumnDataGridView<K, V> extends DecoratorDataGridView<K
             }
 
             @Override
-            public void setController(final CellController<V> cellController) {
+            public void setController(final PrimaryCellController<V> cellController) {
             }
 
             @Override


### PR DESCRIPTION
There are multiple issues with extended cell mode:

- Cells sometimes keep old value together with new value leading to a broken display (with checkboxes behaving differently and, thus, not in sync)
- A "draw()" is made for each cell becoming "extended" (which trigger a query); for a screen with, let's say, 15 rows and 15 columns, we can thus have (15 x 15) + 1 = 226 queries
- The variable columnView.extendedCells seems to suffer from a memory leak since elements are not removed when filters or sorting changes (which, on DB blotters, can cause completely new objects to be displayed)