### PR TITLE
Add Exception handling and count on Datagrid blotters

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DataGridController.java
@@ -38,6 +38,7 @@ import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
 import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
 import com.ponysdk.core.ui.datagrid2.view.DataGridView;
+import com.ponysdk.core.util.Pair;
 
 /**
  * @author mbagdouri
@@ -125,7 +126,7 @@ public interface DataGridController<K, V> {
      * sometimes
      */
     void prepareLiveDataOnScreen(int dataSrcRowIndex, int dataSize, DataGridSnapshot threadSnapshot,
-                                 Consumer<DefaultDataGridController<K, V>.DataSrcResult> consumer);
+    		Consumer<Pair<DefaultDataGridController<K, V>.DataSrcResult, Throwable>> consumer);
 
     /**
      * Insert or replace the value

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/SpyDataGridController.java
@@ -37,6 +37,7 @@ import com.ponysdk.core.ui.datagrid2.column.ColumnDefinition;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfig;
 import com.ponysdk.core.ui.datagrid2.config.DataGridConfigBuilder;
 import com.ponysdk.core.ui.datagrid2.view.DataGridSnapshot;
+import com.ponysdk.core.util.Pair;
 
 /**
  * @author mbagdouri
@@ -250,7 +251,7 @@ public abstract class SpyDataGridController<K, V> implements DataGridController<
 
     @Override
     public void prepareLiveDataOnScreen(final int dataSrcRowIndex, final int dataSize, final DataGridSnapshot threadSnapshot,
-                                        final Consumer<DefaultDataGridController<K, V>.DataSrcResult> consumer) {
+                                        final Consumer<Pair<DefaultDataGridController<K, V>.DataSrcResult, Throwable>> consumer) {
         controller.prepareLiveDataOnScreen(dataSrcRowIndex, dataSize, threadSnapshot, consumer);
     }
 

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/ColumnFilterFooterDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/ColumnFilterFooterDataGridView.java
@@ -66,7 +66,7 @@ public class ColumnFilterFooterDataGridView<K, V> extends DecoratorDataGridView<
         addDrawListener(this::enableFooter);
     }
 
-    private void enableFooter() {
+    private void enableFooter(int rowCount) {
         if (disabledFooter == null) return;
         disabledFooter.setEnabled(true);
         disabledFooter.focus();

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DataGridView.java
@@ -22,6 +22,7 @@ package com.ponysdk.core.ui.datagrid2.view;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.ponysdk.core.ui.basic.IsPWidget;
@@ -228,6 +229,8 @@ public interface DataGridView<K, V> extends IsPWidget {
      * Removes a {@link DrawListener}
      */
     void removeDrawListener(DrawListener drawListener);
+    
+    void setExceptionHandler(Function<Throwable, String> handler);
 
     public static class DecodeException extends Exception {
 
@@ -256,6 +259,6 @@ public interface DataGridView<K, V> extends IsPWidget {
 
     public interface DrawListener {
 
-        void onDraw();
+        void onDraw(int rowCount);
     }
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DecoratorDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DecoratorDataGridView.java
@@ -23,6 +23,7 @@ package com.ponysdk.core.ui.datagrid2.view;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.ponysdk.core.ui.basic.PWidget;
@@ -193,6 +194,11 @@ public class DecoratorDataGridView<K, V> implements DataGridView<K, V> {
     @Override
     public void pause() {
 		view.pause();
+	}
+
+	@Override
+	public void setExceptionHandler(Function<Throwable, String> handler) {
+		view.setExceptionHandler(handler);
 	}
 
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/RowSelectorColumnDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/RowSelectorColumnDataGridView.java
@@ -64,7 +64,7 @@ public class RowSelectorColumnDataGridView<K, V> extends DecoratorDataGridView<K
         decoratorAdapter = new RowSelectorColumnDataGridAdapter(adapter);
         super.setAdapter(decoratorAdapter);
         decoratorAdapter.addColumnActionListeners();
-        addDrawListener(() -> decoratorAdapter.rowSelectorColumn.refreshHeader());
+        addDrawListener(count -> decoratorAdapter.rowSelectorColumn.refreshHeader());
     }
 
     @Override


### PR DESCRIPTION
This Pull request changes datagrid blotters:
- It adds the possibility to listen the total count of row for each draw
- It adds the possibility to display an error message in case of an exception occurs