### PR TITLE
Add configuration to DropDownContainer to stop click event propagation

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DefaultDropDownContainerConfiguration.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DefaultDropDownContainerConfiguration.java
@@ -36,6 +36,7 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
     private DropDownCloseOnClickMode closeOnClickMode = DropDownCloseOnClickMode.DEFAULT;
     private boolean clearTitleButtonEnabled = true;
     private boolean eventOnlyEnabled;
+    private boolean isStopClickEvent;
 
     public DefaultDropDownContainerConfiguration() {
         super();
@@ -158,5 +159,16 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
     public DropDownContainerConfiguration enabledEventOnly(){
         this.eventOnlyEnabled = true;
         return this;
+    }
+
+    @Override
+    public boolean isStopClickEventEnabled() {
+        return this.isStopClickEvent;
+    }
+
+    @Override
+    public DropDownContainerConfiguration enableStopClickEvent() {
+        this.isStopClickEvent = true;
+        return null;
     }
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
@@ -159,6 +159,11 @@ public abstract class DropDownContainer<V, C extends DropDownContainerConfigurat
                 });
             }
 
+            if (configuration.isStopClickEventEnabled()) {
+                mainButton.stopEvent(PEventType.ONCLICK);
+                stateButton.stopEvent(PEventType.ONCLICK);
+            }
+
             if (customContainer != null) {
                 container.add(customContainer);
                 customContainer.asWidget().addStyleName(STYLE_CONTAINER_CUSTOM);

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerConfiguration.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerConfiguration.java
@@ -23,8 +23,6 @@
 
 package com.ponysdk.core.ui.dropdown;
 
-import com.ponysdk.core.ui.listbox.ListBoxConfiguration;
-
 public interface DropDownContainerConfiguration {
 
     public enum DropDownCloseOnClickMode {
@@ -83,4 +81,8 @@ public interface DropDownContainerConfiguration {
     boolean isEventOnlyEnabled();
 
     DropDownContainerConfiguration enabledEventOnly();
+
+    boolean isStopClickEventEnabled();
+
+    DropDownContainerConfiguration enableStopClickEvent();
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/ListBoxConfiguration.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/ListBoxConfiguration.java
@@ -36,7 +36,6 @@ public final class ListBoxConfiguration extends DefaultDropDownContainerConfigur
     private Integer displaySelectionLimit;
     private String displaySelectionLabel;
     private boolean groupEnabled;
-    private boolean eventOnlyEnabled;
 
     public String getNoMatchesLabel() {
         return noMatchesLabel;


### PR DESCRIPTION
- add isStopClickEvent flag to DefaultDropDownContainerConfiguration
- stop the click event propagation on DropDownContainer#mainButton and DropDownContainer#stateButton
- remove unused eventOnlyEnabled flag from ListBoxConfiguration
- remove unused import from DropDownContainerConfiguration