### PR TITLE
Allow Data Grid controller to select an interval of data instead of one single data

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/controller/DefaultDataGridController.java
@@ -503,12 +503,14 @@ public class DefaultDataGridController<K, V> implements DataGridController<K, V>
 
     @Override
     public void select(final K k) {
-        dataSource.select(k);
+        final Interval interval = dataSource.select(k);
+        if (interval != null) refreshRows(interval.from, interval.to);
     }
 
     @Override
     public void unselect(final K k) {
-        dataSource.unselect(k);
+        final Interval interval = dataSource.unselect(k);
+        if (interval != null) refreshRows(interval.from, interval.to);
     }
 
     @Override

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DataGridSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DataGridSource.java
@@ -158,12 +158,12 @@ public interface DataGridSource<K, V> {
     /**
      * Selects a row
      */
-    void select(final K k);
+    Interval select(final K k);
 
     /**
      * Unselects a row
      */
-    void unselect(final K k);
+    Interval unselect(final K k);
 
     /**
      * Selects all rows in the dataGrid

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DefaultCacheDataSource.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/datasource/DefaultCacheDataSource.java
@@ -243,16 +243,18 @@ public class DefaultCacheDataSource<K, V> extends AbstractDataSource<K, V> {
     }
 
     @Override
-    public void select(final K k) {
+    public Interval select(final K k) {
         final DefaultRow<V> row = cache.get(k);
-        if (row == null || !selectedKeys.add(k) || !row.isAccepted()) return;
-        insertRow(liveSelectedData, row);
+        if (row == null || !selectedKeys.add(k) || !row.isAccepted()) return null;
+        int i = insertRow(liveSelectedData, row);
+        return new Interval(i, i);
     }
 
     @Override
-    public void unselect(final K k) {
+    public Interval unselect(final K k) {
         final DefaultRow<V> row = cache.get(k);
-        if (row == null || !selectedKeys.remove(k) || !row.isAccepted()) return;
-        removeRow(liveSelectedData, row);
+        if (row == null || !selectedKeys.remove(k) || !row.isAccepted()) return null;
+        int i = removeRow(liveSelectedData, row);
+        return new Interval(i, i);
     }
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DefaultDataGridView.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/datagrid2/view/DefaultDataGridView.java
@@ -1041,35 +1041,11 @@ public final class DefaultDataGridView<K, V> implements DataGridView<K, V>, Data
         void select() {
             if (key == null || !controller.isSelectable(key)) return;
             controller.select(key);
-            adapter.onSelectRow(unpinnedRow);
-            unpinnedRow.setAttribute(SELECTED_ATTRIBUTE);
-            adapter.onSelectRow(pinnedRow);
-            pinnedRow.setAttribute(SELECTED_ATTRIBUTE);
-            for (final CellManager<V> cell : pinnedCells) {
-                cell.primary.select();
-                if (extended && cell.extended != null) cell.extended.select();
-            }
-            for (final CellManager<V> cell : unpinnedCells) {
-                cell.primary.select();
-                if (extended && cell.extended != null) cell.extended.select();
-            }
         }
 
         void unselect() {
             if (key == null || !controller.isSelectable(key)) return;
             controller.unselect(key);
-            adapter.onUnselectRow(unpinnedRow);
-            unpinnedRow.removeAttribute(SELECTED_ATTRIBUTE);
-            adapter.onUnselectRow(pinnedRow);
-            pinnedRow.removeAttribute(SELECTED_ATTRIBUTE);
-            for (final CellManager<V> cell : pinnedCells) {
-                cell.primary.unselect();
-                if (extended && cell.extended != null) cell.extended.select();
-            }
-            for (final CellManager<V> cell : unpinnedCells) {
-                cell.primary.unselect();
-                if (extended && cell.extended != null) cell.extended.select();
-            }
         }
 
     }


### PR DESCRIPTION
- CacheDataSource#select and CacheDataSource#unselct will now return an Interval of rows to select/unselect.
- The DefaultDataGridController will now trigger the redraw but only if there is rows to select/unselec.t
- Remove dupplicated code of the defaultDataGridView because the contoller will now trigger a redrawy anyway.