### PR TITLE
Improving log levels of WebSocket and PonySDKWebDriver and adding doubleClick method

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocket.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocket.java
@@ -56,8 +56,8 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
 
     private static final String MSG_RECEIVED = "Message received from terminal : UIContext #{} on {} : {}";
     private static final Logger log = LoggerFactory.getLogger(WebSocket.class);
-    private static final Logger LOGGER_IN = LoggerFactory.getLogger("WebSocket-IN");
-    private static final Logger LOGGER_OUT = LoggerFactory.getLogger("WebSocket-OUT");
+    private static final Logger logger_in = LoggerFactory.getLogger("WebSocket-IN");
+    private static final Logger logger_out = LoggerFactory.getLogger("WebSocket-OUT");
 
     private ServletUpgradeRequest request;
     private WebsocketMonitor monitor;
@@ -193,7 +193,7 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
 
     private void processInstructions(final JsonObject jsonObject) {
         final String applicationInstructions = ClientToServerModel.APPLICATION_INSTRUCTIONS.toStringValue();
-        LOGGER_IN.trace("UIContext #{} : {}", this.uiContext.getID(), jsonObject);
+        logger_in.trace("UIContext #{} : {}", this.uiContext.getID(), jsonObject);
         uiContext.execute(() -> {
             final JsonArray appInstructions = jsonObject.getJsonArray(applicationInstructions);
             for (int i = 0; i < appInstructions.size(); i++) {
@@ -309,7 +309,7 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
     @Override
     public void encode(final ServerToClientModel model, final Object value) {
         try {
-            LOGGER_OUT.trace("UIContext #{} : {} {}", this.uiContext.getID(), model, value);
+            logger_out.trace("UIContext #{} : {} {}", this.uiContext.getID(), model, value);
             websocketPusher.encode(model, value);
             if (listener != null) listener.onOutgoingPonyFrame(model, value);
         } catch (final IOException e) {

--- a/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocket.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocket.java
@@ -56,8 +56,8 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
 
     private static final String MSG_RECEIVED = "Message received from terminal : UIContext #{} on {} : {}";
     private static final Logger log = LoggerFactory.getLogger(WebSocket.class);
-    private static final Logger logger_in = LoggerFactory.getLogger("WebSocket-IN");
-    private static final Logger logger_out = LoggerFactory.getLogger("WebSocket-OUT");
+    private static final Logger loggerIn = LoggerFactory.getLogger("WebSocket-IN");
+    private static final Logger loggerOut = LoggerFactory.getLogger("WebSocket-OUT");
 
     private ServletUpgradeRequest request;
     private WebsocketMonitor monitor;
@@ -193,7 +193,7 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
 
     private void processInstructions(final JsonObject jsonObject) {
         final String applicationInstructions = ClientToServerModel.APPLICATION_INSTRUCTIONS.toStringValue();
-        logger_in.trace("UIContext #{} : {}", this.uiContext.getID(), jsonObject);
+        loggerIn.trace("UIContext #{} : {}", this.uiContext.getID(), jsonObject);
         uiContext.execute(() -> {
             final JsonArray appInstructions = jsonObject.getJsonArray(applicationInstructions);
             for (int i = 0; i < appInstructions.size(); i++) {
@@ -309,7 +309,7 @@ public class WebSocket implements WebSocketListener, WebsocketEncoder {
     @Override
     public void encode(final ServerToClientModel model, final Object value) {
         try {
-            logger_out.trace("UIContext #{} : {} {}", this.uiContext.getID(), model, value);
+            loggerOut.trace("UIContext #{} : {} {}", this.uiContext.getID(), model, value);
             websocketPusher.encode(model, value);
             if (listener != null) listener.onOutgoingPonyFrame(model, value);
         } catch (final IOException e) {

--- a/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocketPusher.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocketPusher.java
@@ -95,45 +95,45 @@ public class WebSocketPusher extends AutoFlushedBuffer implements WriteCallback 
      * @param value The type can be primitives, String or Object[]
      */
     void encode(final ServerToClientModel model, final Object value) throws IOException {
-        if (log.isDebugEnabled()) log.debug("Writing in the buffer : {} => {}", model, value);
-            switch (model.getTypeModel()) {
-                case NULL:
-                    write(model);
-                    break;
-                case BOOLEAN:
-                    write(model, (boolean) value);
-                    break;
-                case BYTE:
-                    write(model, (byte) value);
-                    break;
-                case SHORT:
-                    write(model, (short) value);
-                    break;
-                case UINT31:
-                    writeUint31(model, (int) value);
-                    break;
-                case INTEGER:
-                    write(model, (int) value);
-                    break;
-                case LONG:
-                    write(model, (long) value);
-                    break;
-                case DOUBLE:
-                    write(model, (double) value);
-                    break;
-                case FLOAT:
-                    write(model, (float) value);
-                    break;
-                case STRING:
-                    write(model, (String) value);
-                    break;
-                case ARRAY:
-                    write(model, (Object[]) value);
-                    break;
-                default:
-                    log.error("Unknown model type : {}", model.getTypeModel());
-                    break;
-            }
+        log.debug("Writing in the buffer : {} => {}", model, value);
+        switch (model.getTypeModel()) {
+            case NULL:
+                write(model);
+                break;
+            case BOOLEAN:
+                write(model, (boolean) value);
+                break;
+            case BYTE:
+                write(model, (byte) value);
+                break;
+            case SHORT:
+                write(model, (short) value);
+                break;
+            case UINT31:
+                writeUint31(model, (int) value);
+                break;
+            case INTEGER:
+                write(model, (int) value);
+                break;
+            case LONG:
+                write(model, (long) value);
+                break;
+            case DOUBLE:
+                write(model, (double) value);
+                break;
+            case FLOAT:
+                write(model, (float) value);
+                break;
+            case STRING:
+                write(model, (String) value);
+                break;
+            case ARRAY:
+                write(model, (Object[]) value);
+                break;
+            default:
+                log.error("Unknown model type : {}", model.getTypeModel());
+                break;
+        }
     }
 
     private void write(final ServerToClientModel model) throws IOException {

--- a/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
@@ -52,8 +52,8 @@ import java.util.function.ToIntFunction;
 public class PonySDKWebDriver implements WebDriver {
 
     private static final Logger log = LoggerFactory.getLogger(PonySDKWebDriver.class);
-    private static final Logger logger_in = LoggerFactory.getLogger("PonySDKWebDriver-IN");
-    private static final Logger logger_out = LoggerFactory.getLogger("PonySDKWebDriver-OUT");
+    private static final Logger loggerIn = LoggerFactory.getLogger("PonySDKWebDriver-IN");
+    private static final Logger loggerOut = LoggerFactory.getLogger("PonySDKWebDriver-OUT");
 
     private static final ThreadLocal<byte[]> byteArrays = ThreadLocal.withInitial(() -> new byte[32]);
 
@@ -503,7 +503,7 @@ public class PonySDKWebDriver implements WebDriver {
     }
 
     private void onMessage(final List<PonyFrame> message) {
-        logger_in.trace("{}", message);
+        loggerIn.trace("{}", message);
         for (final PonyFrame frame : message) {
             onMessageSwitch.getOrDefault(frame.getModel(), DO_NOTHING_WITH_FRAME).accept(message, frame);
         }
@@ -577,7 +577,7 @@ public class PonySDKWebDriver implements WebDriver {
 
     public void sendMessage(final JsonObject json) {
         final String str = json.toString();
-        logger_out.trace("{}", str);
+        loggerOut.trace(str);
         sendMessage(str);
         messageListener.onSendMessage(json);
     }

--- a/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
@@ -51,8 +51,12 @@ import java.util.function.ToIntFunction;
 
 public class PonySDKWebDriver implements WebDriver {
 
-    private final static Logger log = LoggerFactory.getLogger(PonySDKWebDriver.class);
-    private final static ThreadLocal<byte[]> byteArrays = ThreadLocal.withInitial(() -> new byte[32]);
+    private static final Logger log = LoggerFactory.getLogger(PonySDKWebDriver.class);
+    private static final Logger LOGGER_IN = LoggerFactory.getLogger("PonySDKWebDriver-IN");
+    private static final Logger LOGGER_OUT = LoggerFactory.getLogger("PonySDKWebDriver-OUT");
+
+    private static final ThreadLocal<byte[]> byteArrays = ThreadLocal.withInitial(() -> new byte[32]);
+
     private final ConcurrentHashMap<Integer, PonyWebElement> elements = new ConcurrentHashMap<>();
     private final PonySearchContext globalContext = new PonySearchContext(Collections.unmodifiableCollection(elements.values()),
             false);
@@ -499,7 +503,7 @@ public class PonySDKWebDriver implements WebDriver {
     }
 
     private void onMessage(final List<PonyFrame> message) {
-        log.debug("IN : {}", message);
+        LOGGER_IN.trace("{}", message);
         for (final PonyFrame frame : message) {
             onMessageSwitch.getOrDefault(frame.getModel(), DO_NOTHING_WITH_FRAME).accept(message, frame);
         }
@@ -573,7 +577,7 @@ public class PonySDKWebDriver implements WebDriver {
 
     public void sendMessage(final JsonObject json) {
         final String str = json.toString();
-        log.debug("OUT : {}", str);
+        LOGGER_OUT.trace("{}", str);
         sendMessage(str);
         messageListener.onSendMessage(json);
     }

--- a/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
@@ -52,8 +52,8 @@ import java.util.function.ToIntFunction;
 public class PonySDKWebDriver implements WebDriver {
 
     private static final Logger log = LoggerFactory.getLogger(PonySDKWebDriver.class);
-    private static final Logger LOGGER_IN = LoggerFactory.getLogger("PonySDKWebDriver-IN");
-    private static final Logger LOGGER_OUT = LoggerFactory.getLogger("PonySDKWebDriver-OUT");
+    private static final Logger logger_in = LoggerFactory.getLogger("PonySDKWebDriver-IN");
+    private static final Logger logger_out = LoggerFactory.getLogger("PonySDKWebDriver-OUT");
 
     private static final ThreadLocal<byte[]> byteArrays = ThreadLocal.withInitial(() -> new byte[32]);
 
@@ -503,7 +503,7 @@ public class PonySDKWebDriver implements WebDriver {
     }
 
     private void onMessage(final List<PonyFrame> message) {
-        LOGGER_IN.trace("{}", message);
+        logger_in.trace("{}", message);
         for (final PonyFrame frame : message) {
             onMessageSwitch.getOrDefault(frame.getModel(), DO_NOTHING_WITH_FRAME).accept(message, frame);
         }
@@ -577,7 +577,7 @@ public class PonySDKWebDriver implements WebDriver {
 
     public void sendMessage(final JsonObject json) {
         final String str = json.toString();
-        LOGGER_OUT.trace("{}", str);
+        logger_out.trace("{}", str);
         sendMessage(str);
         messageListener.onSendMessage(json);
     }

--- a/ponysdk/src/main/java/com/ponysdk/driver/PonyWebElement.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/PonyWebElement.java
@@ -92,6 +92,10 @@ public class PonyWebElement implements WebElement {
         sendApplicationInstruction(ClientToServerModel.DOM_HANDLER_TYPE, DomHandlerType.CLICK.getValue());
     }
 
+    public void doubleClick() {
+        sendApplicationInstruction(ClientToServerModel.DOM_HANDLER_TYPE, DomHandlerType.DOUBLE_CLICK.getValue());
+    }
+
     @Override
     public void submit() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
- Logs levels
Creation of two loggers (trace level) for in and out messages in WebSocket and PonySDKWebDriver
Setting trace levels for round-trip, terminal and network measurement logs (WebSocket)

- Adding doubleClick method to PonyWebElement
- Fixing switch indentation in WebSocketPusher#encode