### PR TITLE
Adding methods to change sessionListener and fixing performance logout issue

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/writer/ModelWriter.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/writer/ModelWriter.java
@@ -26,6 +26,7 @@ package com.ponysdk.core.writer;
 import java.lang.ref.WeakReference;
 
 import com.ponysdk.core.model.ServerToClientModel;
+import com.ponysdk.core.server.application.UIContext;
 import com.ponysdk.core.server.websocket.WebsocketEncoder;
 import com.ponysdk.core.ui.basic.PWindow;
 
@@ -56,11 +57,15 @@ public class ModelWriter {
      * @param value The type can be primitives, String or Object[]
      */
     public void write(final ServerToClientModel model, final Object value) {
-        encoder.encode(model, value);
+        if (UIContext.get().isAlive()) {
+            encoder.encode(model, value);
+        }
     }
 
     public void endObject() {
-        encoder.endObject();
+        if (UIContext.get().isAlive()) {
+            encoder.endObject();
+        }
     }
 
     public PWindow getCurrentWindow() {

--- a/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/PonySDKWebDriver.java
@@ -621,6 +621,11 @@ public class PonySDKWebDriver implements WebDriver {
         return handleImplicitCommunication;
     }
 
+    public void ignoreSessionStatusChanges() {
+        this.client.setSessionListener(INDIFFERENT_SESSION_LISTENER);
+    }
+
+
     private final static PonyMessageListener INDIFFERENT_MSG_LISTENER = new PonyMessageListener() {
 
         @Override

--- a/ponysdk/src/main/java/com/ponysdk/driver/WebsocketClient.java
+++ b/ponysdk/src/main/java/com/ponysdk/driver/WebsocketClient.java
@@ -75,7 +75,7 @@ class WebsocketClient implements AutoCloseable {
 
     private final MessageHandler.Whole<ByteBuffer> handler;
     private final List<Extension> extensions;
-    private final PonySessionListener sessionListener;
+    private PonySessionListener sessionListener;
 
     public WebsocketClient(final Whole<ByteBuffer> handler, final PonyBandwithListener bandwidthListener,
             final PonySessionListener sessionListener) {
@@ -155,4 +155,7 @@ class WebsocketClient implements AutoCloseable {
         return session != null ? session.getId() : null;
     }
 
+    public void setSessionListener(PonySessionListener sessionListener){
+        this.sessionListener = sessionListener;
+    }
 }


### PR DESCRIPTION
- Checking if UIContext is alive in the write() and endObject() methods of ModelWriter (to solve logout perofrmance issue we faced while testing the live order blotter).
- Adding a method to change the sessionListener to INDIFFERENT_SESSION_LISTENER in PonySDKWebDriver.
- Adding a setter to sessionListener in WebsocketClient.