### PR TITLE
Removing useless purge

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/server/concurrent/PScheduler.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/concurrent/PScheduler.java
@@ -158,7 +158,6 @@ public class PScheduler {
     private void purge(final UIRunnable uiRunnable) {
         final Set<UIRunnable> uiRunnables = runnablesByUIContexts.get(uiRunnable.getUIContext());
         if (uiRunnables != null) uiRunnables.remove(uiRunnable);
-        executor.purge();
     }
 
     private void registerTask(final UIRunnable runnable) {


### PR DESCRIPTION
Every time we schedule a task using the schedule method (which means the task is not periodic), we will call the executor purge.
This is useless, since once the task has run, it is removed from the queue.

This executor.purge is also called when we cancel a task. Once more, it is not necessary, since cancelled task will be picked up, not run and never re-inserted in the queue.

We can therefore safely remove the executor.purge from the PScheduler.purge