### PR TITLE
Deleting duplicated logs of pony messages sent to the browser

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocketPusher.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/server/websocket/WebSocketPusher.java
@@ -95,7 +95,6 @@ public class WebSocketPusher extends AutoFlushedBuffer implements WriteCallback 
      * @param value The type can be primitives, String or Object[]
      */
     void encode(final ServerToClientModel model, final Object value) throws IOException {
-        log.debug("Writing in the buffer : {} => {}", model, value);
         switch (model.getTypeModel()) {
             case NULL:
                 write(model);


### PR DESCRIPTION
The line 98 in WebSocketPusher, to log messages written in the buffer, is useless.

We are already logging these messages in the WebSocket class thanks to the Pull Request _Improving log levels of WebSocket and PonySDKWebDriver and adding doubleClick method #291_ (commit 94683172c2c1738fadaf49f239ad6e664b217806) : 
`loggerOut.trace("UIContext #{} : {} {}", this.uiContext.getID(), model, value);`