### PR TITLE
[Datagrid] Avoid getting rows with 0 height

### DIFF
--- a/ponysdk/src/main/resources/script/ponysdk.js
+++ b/ponysdk/src/main/resources/script/ponysdk.js
@@ -625,6 +625,11 @@ _UTF8 = undefined;
 		if(this.rowHeight == 0) {
 		    this.updateRowHeight(0); // Initialize rowHeight...
 		    if(this.rowHeight == 0) return;
+		    else { // We need to change the height of all already existing rows
+		        for(var i = 1; i < this.relRowCount; i++) {
+		            this.updateRowHeight(i);
+		        }
+		    }
 		}
         this.loadingData.style.display = null;
 		this.viewHeight = visibleHeight;


### PR DESCRIPTION
If we hide a blotter but initialize it with empty rows, they will have a 0 height. Then, when we show the blotter, lines will fill but existing ones will keep 0 height.
This pull request fix this.