### PR TITLE
Make Windows refresh quicker (using F5)

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/terminal/ui/PTWindowManager.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/terminal/ui/PTWindowManager.java
@@ -34,7 +34,7 @@ import elemental.util.MapFromIntTo;
 
 public class PTWindowManager {
 
-    private static final int IS_ALIVE_WINDOWS_TIMER = 10000; // 10 seconds
+    private static final int IS_ALIVE_WINDOWS_TIMER = 1000; // 1 seconds
 
     private static final Logger log = Logger.getLogger(PTWindowManager.class.getName());
 


### PR DESCRIPTION
When a user needs to refresh a window of a given module, it takes time to appear again.
Since F5 is used as workaround for a lot of issues, this can be annoying.

I tested a very small change in PonySDK terminal package and it solves this issue but we should check if this does not create other ones. And maybe, this is not the clean way of doing it ?