### PR TITLE
DropDownContainerAddon Remove event prevention for ArrowLeft and ArrowRight

### DIFF
--- a/ponysdk/src/main/resources/script/ponysdk.js
+++ b/ponysdk/src/main/resources/script/ponysdk.js
@@ -1116,7 +1116,7 @@ _UTF8 = undefined;
                         let path = event.composedPath();
                         if (isNested(path[path.length - 5])) return;
 
-                        if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(event.code) > -1 ||
+                        if (["ArrowUp", "ArrowDown"].indexOf(event.code) > -1 ||
                             "Space" == event.code && !that.spaceAuthorized) {
                             event.preventDefault();
                         }


### PR DESCRIPTION
We need left and right arrow event when we have a text input in the container.