### PR TITLE
Enhance the user experience of the multilevel dropdown

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
@@ -179,7 +179,13 @@ public abstract class DropDownContainer<V, C extends DropDownContainerConfigurat
             container.add(defaultContainer);
 
             final PClickHandler clickHandler = e -> {
-                setContainerVisible(!container.isVisible());
+                final boolean visible = !container.isVisible();
+                if (configuration.isMultilevelEnabled() && !visible && isOpen()) {
+                    // To enhance the user experience of the multilevel dropdown, we prevent hiding the sublevel on click.
+                    // Instead, the task of hiding the sublevel will be performed when the user hovers the mouse over it.
+                    return;
+                }
+                setContainerVisible(visible);
             };
             mainButton.addClickHandler(clickHandler);
             stateButton.addClickHandler(clickHandler);

--- a/ponysdk/src/main/resources/script/ponysdk.js
+++ b/ponysdk/src/main/resources/script/ponysdk.js
@@ -1150,10 +1150,12 @@ _UTF8 = undefined;
             let timerDelay = 400;
             let timer;
   
-            this.mouseEnterEventListener = function (event) {                
+            this.mouseEnterEventListener = function (event) {
                 timer = setTimeout(function() {             
-                  event.target.click()
-                  simulateMouseDown(event.target, event.clientX, event.clientY);
+                    let dropdown = event.target.parentNode;
+                    if(dropdown && dropdown.classList.contains("dd-container-opened")) return;          
+                    event.target.click()
+                    simulateMouseDown(event.target, event.clientX, event.clientY);
                 }, timerDelay);
             }
             


### PR DESCRIPTION
The objective of this improvement is to address the issue of conflicting actions between mouse hovering and mouse clicking in the multilevel dropdown. Currently, if a user clicks while also hovering over the dropdown, it simultaneously opens and closes the target. To align with existing contextual menus (such as those in Windows, Google Chrome, Eclipse, etc.), we have decided to prevent the click/hover action from closing an already opened sublevel.