### PR TITLE
Clarify multilevel dropdown behavior

### DIFF
--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DefaultDropDownContainerConfiguration.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DefaultDropDownContainerConfiguration.java
@@ -37,7 +37,7 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
     private boolean clearTitleButtonEnabled = true;
     private boolean eventOnlyEnabled;
     private boolean stopClickEvent;
-    private DropDownPosition position = DropDownPosition.INSIDE;
+    private boolean dropRight;
     private boolean multilevelEnabled;
 
     public DefaultDropDownContainerConfiguration() {
@@ -168,6 +168,7 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
         return this.stopClickEvent;
     }
 
+    
     @Override
     public DropDownContainerConfiguration enableStopClickEvent() {
         this.stopClickEvent = true;
@@ -175,13 +176,13 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
     }
 
     @Override
-    public DropDownPosition getPosition() {
-        return position;
+    public boolean isPositionDropRight() {
+        return this.dropRight;
     }
 
     @Override
-    public DropDownContainerConfiguration setPosition(DropDownPosition position) {
-        this.position = position;
+    public DropDownContainerConfiguration setPositionDropRight(final boolean dropRight) {
+        this.dropRight  = dropRight;
         return this;
     }
 
@@ -192,7 +193,9 @@ public class DefaultDropDownContainerConfiguration implements DropDownContainerC
 
     @Override
     public DropDownContainerConfiguration enableMultilevel() {
+        this.dropRight  = true;
         this.multilevelEnabled = true;
         return this;
     }
+
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainer.java
@@ -44,7 +44,6 @@ import com.ponysdk.core.ui.basic.event.POpenEvent;
 import com.ponysdk.core.ui.basic.event.POpenHandler;
 import com.ponysdk.core.ui.basic.event.PValueChangeEvent;
 import com.ponysdk.core.ui.basic.event.PValueChangeHandler;
-import com.ponysdk.core.ui.dropdown.DropDownContainerConfiguration.DropDownPosition;
 import com.ponysdk.core.ui.eventbus.HandlerRegistration;
 import com.ponysdk.core.ui.model.PEventType;
 import com.ponysdk.core.ui.model.PKeyCodes;
@@ -96,9 +95,9 @@ public abstract class DropDownContainer<V, C extends DropDownContainerConfigurat
         this.widget = Element.newPFlowPanel();
         this.widget.addStyleName(STYLE_CONTAINER_WIDGET);
         this.widget.setAttribute(ATTRIBUTE_ID, widget.getID() + "");
-        final boolean stick = configuration.getPosition() == DropDownPosition.OUTSIDE;
-        this.container = new DropDownContainerAddon(widget, stick, stick, configuration.isMultilevelEnabled());
+        this.container =  configuration.isMultilevelEnabled() ? DropDownContainerAddon.newMultilevelDopdown(widget) : new DropDownContainerAddon(widget);
         this.container.addStyleName(STYLE_CONTAINER_ADDON);
+        if (configuration.isPositionDropRight()) container.setDropRight();
     }
 
     public abstract V getValue();

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerAddon.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerAddon.java
@@ -36,7 +36,6 @@ import com.ponysdk.core.ui.basic.PAddOnComposite;
 import com.ponysdk.core.ui.basic.PPanel;
 import com.ponysdk.core.ui.basic.PWidget;
 import com.ponysdk.core.ui.basic.event.PDomEvent.Type;
-import com.ponysdk.core.ui.dropdown.DropDownContainerConfiguration.DropDownPosition;
 import com.ponysdk.core.ui.eventbus.EventHandler;
 import com.ponysdk.core.ui.model.PEventType;
 
@@ -51,12 +50,12 @@ public class DropDownContainerAddon extends PAddOnComposite<PPanel> {
 
     private static final String PARENT_ID = "parentId";
     private static final String STICK_LEFT = "stickLeft";
-    private static final String STICK_OUTSIDE = "stickOutside";
     private static final String MULTILEVEL = "multiLevel";
     private static final String UPDATE_POSITION = "updatePosition";
     private static final String ADJUST_POSITION = "adjustPosition";
     private static final String SET_VISIBLE = "setVisible";
     private static final String DISABLE_SPACE_WHEN_OPENED = "disableSpaceWhenOpened";
+    private static final String POSITION_RIGHT = "setDropRight";
     private static final String WINDOW_EVENT = "windowEvent";
     private static final String RESIZE = "resize";
     private static final String SCROLL = "scroll";
@@ -67,17 +66,29 @@ public class DropDownContainerAddon extends PAddOnComposite<PPanel> {
     private final PWidget parent;
     private final Set<DropDownContainerAddonListener> listeners;
 
-    public DropDownContainerAddon(final PWidget parent) {
-        this(parent, true, false, false);
+    /**
+     * The multilevel dropdown is meant to be stuck to the left of the container.
+     * Use this static builder to ensure you create a multilevel instance with the right settings
+     * 
+     * @param parent
+     * @return
+     */
+    public static DropDownContainerAddon newMultilevelDopdown(final PWidget parent) {
+        return new DropDownContainerAddon(parent, true,  true);
     }
 
-    public DropDownContainerAddon(final PWidget parent, final boolean stickLeft, final boolean stickOutside, final boolean multilevel) {
-        super(Element.newPFlowPanel(), createJsonObject(parent.getID(), stickLeft, stickOutside, multilevel));
+    public DropDownContainerAddon(final PWidget parent) {
+        this(parent, true,  false);
+    }
+
+    private DropDownContainerAddon(final PWidget parent, final boolean stickLeft, final boolean multilevel) {
+        super(Element.newPFlowPanel(), createJsonObject(parent.getID(), stickLeft, multilevel));
         this.parent = parent;
         widget.setStyleProperty(PROPERTY_POSITION, PROPERTY_ABSOLUTE);
         widget.setStyleProperty(PROPERTY_TOP, PROPERTY_0);
         if (stickLeft) {
-            if (!stickOutside) {
+            if (!multilevel) {
+                // The multilevel dropdown is designed to open each new level next to the previous one, so it won't stick to the left of the container.
                 widget.setStyleProperty(PROPERTY_LEFT, PROPERTY_0);
             }
         } else {
@@ -138,6 +149,10 @@ public class DropDownContainerAddon extends PAddOnComposite<PPanel> {
         callTerminalMethod(DISABLE_SPACE_WHEN_OPENED);
     }
 
+    public void setDropRight() {
+        callTerminalMethod(POSITION_RIGHT);
+    }
+
     public boolean isVisible() {
         return visible;
     }
@@ -168,11 +183,10 @@ public class DropDownContainerAddon extends PAddOnComposite<PPanel> {
         dropdown.asWidget().setAttribute("multilvl-parent", String.valueOf(widget.getID()));
     }
 
-    private static JsonObject createJsonObject(final int parentId, final boolean stickLeft, final boolean stickOutside, final boolean multiLevel) {
+    private static JsonObject createJsonObject(final int parentId, final boolean stickLeft, final boolean multiLevel) {
         final JsonObjectBuilder builder = UIContext.get().getJsonProvider().createObjectBuilder();
         builder.add(PARENT_ID, parentId);
         builder.add(STICK_LEFT, stickLeft);
-        builder.add(STICK_OUTSIDE, stickOutside);
         builder.add(MULTILEVEL, multiLevel);
         return builder.build();
     }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerConfiguration.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/dropdown/DropDownContainerConfiguration.java
@@ -36,10 +36,6 @@ public interface DropDownContainerConfiguration {
         FALSE
     }
 
-    enum DropDownPosition {
-        OUTSIDE,
-        INSIDE
-    }
 
     String DEFAULT_TITLE_SEPARATOR = ":";
 
@@ -91,11 +87,12 @@ public interface DropDownContainerConfiguration {
 
     DropDownContainerConfiguration enableStopClickEvent();
 
-    DropDownPosition getPosition();
+    boolean isPositionDropRight();
 
-    DropDownContainerConfiguration setPosition(final DropDownPosition position);
+    DropDownContainerConfiguration setPositionDropRight(final boolean dropRight);
 
     boolean isMultilevelEnabled();
 
     DropDownContainerConfiguration enableMultilevel();
+
 }

--- a/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/MultiLevelDropDownRenderer.java
+++ b/ponysdk/src/main/java/com/ponysdk/core/ui/listbox/MultiLevelDropDownRenderer.java
@@ -10,7 +10,6 @@ import com.ponysdk.core.ui.basic.PWidget;
 import com.ponysdk.core.ui.basic.event.PClickEvent;
 import com.ponysdk.core.ui.basic.event.PClickHandler;
 import com.ponysdk.core.ui.basic.event.PValueChangeHandler;
-import com.ponysdk.core.ui.dropdown.DropDownContainerConfiguration.DropDownPosition;
 import com.ponysdk.core.ui.listbox.ListBox.ListBoxItem;
 import com.ponysdk.core.ui.listbox.ListBox.ListBoxItem.ListBoxItemType;
 
@@ -139,7 +138,6 @@ public class MultiLevelDropDownRenderer<D> implements ListBoxItemRenderer<MultiL
         configuration.enabledEventOnly();
         configuration.disableClearTitleButton();
         configuration.enableStopClickEvent();
-        configuration.setPosition(DropDownPosition.OUTSIDE);
         configuration.enableMultilevel();
         configuration.disableSorting();
         configuration.disableSearch();


### PR DESCRIPTION
The objective is to replace the misleading "stick-outside" property with a more verbose "ismultilevel" one. This will provide clarity regarding the multilevel dropdown approach.

This modification also fixes a bug that might occur when resizing a non-multilevel dropdown. The previous behavior could switch between right and left-sticked corners, resulting in an unpleasant blink for the user.